### PR TITLE
only redirect in production environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,17 +25,17 @@ app.use(redirectSSL.create({ redirectPort: 8443 }))
 
 ### xForwardedProto
 - Default: `true`
-    
+
 Trust and check `x-forwarded-proto` header for HTTPS detection.
 
 ### redirectPort
 - Default: `443`
-    
+
 Redirect users to this port for HTTPS. (`:443` is omitted from URL as is default for `https://` schema)
 
 ### redirectHost
 - Default: `undefined`
-   
+
 Redirects using this value as host, if omitted will use request host for redirects.
 
 **NOTE** It should not contain schema or trailing slashes. (Example: `google.com`)
@@ -47,7 +47,12 @@ Redirect when no SSL detection method is available too. **disable** this option 
 
 ### Status Code
 - Default: `307` *Temporary Redirect*
-   
+
+### redirect
+- Default: Only when `process.env.NODE_ENV === 'production'`
+
+Only enabled in production environment. Force redirecting locally by setting it to `true`
+
 Status code when redirecting. The reason of choosing `307` for default is:
 - It prevents changing method from `POST` TO `GET` by user agents. (If you don't care, use `302` *Found*)
 - Is temporary so if for any reason HTTPS disables on server clients won't hurt. (If you need permanent, use `308` *Permanent Redirect* or `301` *Moved Permanently*)

--- a/index.js
+++ b/index.js
@@ -16,8 +16,9 @@ function create(options) {
 
     return function redirectSSL(req, res, next) {
         const _isHttps = isHTTPS(req, xForwardedProto)
-
-        if (_isHttps === false || (redirectUnknown && _isHttps === null)) {
+        const isProduction = process.env.NODE_ENV === 'production'
+        const shouldRedirect = _isHttps === false || (redirectUnknown && _isHttps === null)
+        if (isProduction && shouldRedirect) {
             const ـredirectURL = 'https://' + (redirectHost || req.headers.host) + _port + req.url
             res.writeHead(statusCode, { Location: ـredirectURL })
             return res.end()

--- a/index.js
+++ b/index.js
@@ -6,19 +6,19 @@ const defaults = {
     redirectPort: 443,
     redirectHost: undefined,
     redirectUnknown: true,
-    statusCode: 307
+    statusCode: 307,
+    redirect: process.env.NODE_ENV === 'production'
 }
 
 // Creates new middleware using provided options
 function create(options) {
-    const { xForwardedProto, redirectPort, redirectHost, statusCode, redirectUnknown } = Object.assign({}, defaults, options)
+    const { xForwardedProto, redirectPort, redirectHost, statusCode, redirectUnknown, redirect } = Object.assign({}, defaults, options)
     const _port = redirectPort === 443 ? '' : (': ' + redirectPort)
 
     return function redirectSSL(req, res, next) {
         const _isHttps = isHTTPS(req, xForwardedProto)
-        const isProduction = process.env.NODE_ENV === 'production'
-        const shouldRedirect = _isHttps === false || (redirectUnknown && _isHttps === null)
-        if (isProduction && shouldRedirect) {
+        const shouldRedirect = _isHttps === false || (redirectUnknown && _isHttps === null) && redirect
+        if (shouldRedirect) {
             const ـredirectURL = 'https://' + (redirectHost || req.headers.host) + _port + req.url
             res.writeHead(statusCode, { Location: ـredirectURL })
             return res.end()
@@ -28,7 +28,7 @@ function create(options) {
     }
 }
 
-// Create a new instance using defaults 
+// Create a new instance using defaults
 const instance = create({})
 
 // Assign create to instance


### PR DESCRIPTION
When using `redirect-ssl`, it's cumbersome to comment/uncomment it from `serverMiddleware` during local development/before pushing to production. It should only be enabled on production.